### PR TITLE
Added symmetric part of the gradient, inner(symgrad(u), grad(v)) is not working

### DIFF
--- a/shenfun/forms/operators.py
+++ b/shenfun/forms/operators.py
@@ -6,7 +6,7 @@ import sympy as sp
 import copy
 from .arguments import Expr, BasisFunction
 
-__all__ = ('div', 'grad', 'Dx', 'curl')
+__all__ = ('div', 'grad', 'symgrad', 'Dx', 'curl')
 
 #pylint: disable=protected-access
 
@@ -170,6 +170,45 @@ def grad(test):
     dv = _expr_from_vector_components(d, test.base)
     dv.simplify()
     return dv
+
+def symgrad(test):
+    """Return the symmetric part of grad(test)
+
+    Parameters
+    ----------
+    test: Expr or BasisFunction
+
+    Note
+    ----
+    Increases the rank of Expr by one
+
+    """
+    assert isinstance(test, (Expr, BasisFunction))
+
+    if isinstance(test, BasisFunction):
+        test = Expr(test)
+
+    ndim = test.dimensions
+    coors = test.function_space().coors
+
+    if coors.is_cartesian:
+        d = []
+        if test.num_components() > 1:
+            for i in range(test.num_components()):
+                for j in range(ndim):
+                    d.append( 1/2 * ( Dx(test[i], j, 1) + Dx(test[j], i, 1) ) )
+        else:
+           raise ValueError("The symmetric part of the gradient of a scalar "
+                            "function does not exist.")
+
+    else:
+        raise NotImplementedError("This method is only implemented for a "
+                                  "Cartesian geometry.")
+
+    dv = _expr_from_vector_components(d, test.base)
+    dv.simplify()
+    return dv
+
 
 def Dx(test, x, k=1):
     """Return k'th order partial derivative in direction x


### PR DESCRIPTION
Hi Mikael,

I wanted to implement the symmetric part of the gradient as a new operator. However, I get an IndexError when I try to assemble `inner(symgrad(u), grad(v))` using the definition of `symgrad` shown below.

Best regards,
Thilo